### PR TITLE
add crefs to sorbet methods

### DIFF
--- a/class.c
+++ b/class.c
@@ -1755,9 +1755,9 @@ rb_define_singleton_method(VALUE obj, const char *name, VALUE (*func)(ANYARGS), 
 }
 
 void
-rb_define_singleton_sorbet_method(VALUE obj, const char *name, rb_sorbet_func_t func, const void *param, void *iseqptr)
+rb_define_singleton_sorbet_method(VALUE obj, const char *name, rb_sorbet_func_t func, const void *param, void *iseqptr, rb_cref_t *cref)
 {
-    rb_add_method_sorbet(singleton_class_of(obj), rb_intern(name), func, (const rb_sorbet_param_t *)param, METHOD_VISI_PUBLIC, iseqptr);
+    rb_add_method_sorbet(singleton_class_of(obj), rb_intern(name), func, (const rb_sorbet_param_t *)param, METHOD_VISI_PUBLIC, iseqptr, cref);
 }
 
 #ifdef rb_define_module_function

--- a/gc.c
+++ b/gc.c
@@ -4902,7 +4902,10 @@ mark_method_entry(rb_objspace_t *objspace, const rb_method_entry_t *me)
 	  case VM_METHOD_TYPE_OPTIMIZED:
 	  case VM_METHOD_TYPE_UNDEF:
 	  case VM_METHOD_TYPE_NOTIMPLEMENTED:
+            break;
 	  case VM_METHOD_TYPE_SORBET:
+	    if (def->body.sorbet.iseqptr) gc_mark(objspace, (VALUE)def->body.sorbet.iseqptr);
+	    gc_mark(objspace, (VALUE)def->body.sorbet.cref);
 	    break;
 	}
     }
@@ -8032,7 +8035,12 @@ gc_ref_update_method_entry(rb_objspace_t *objspace, rb_method_entry_t *me)
           case VM_METHOD_TYPE_OPTIMIZED:
           case VM_METHOD_TYPE_UNDEF:
           case VM_METHOD_TYPE_NOTIMPLEMENTED:
+            break;
           case VM_METHOD_TYPE_SORBET:
+            if (def->body.sorbet.iseqptr) {
+                TYPED_UPDATE_IF_MOVED(objspace, rb_iseq_t *, def->body.sorbet.iseqptr);
+            }
+            TYPED_UPDATE_IF_MOVED(objspace, rb_cref_t *, def->body.sorbet.cref);
             break;
         }
     }

--- a/method.h
+++ b/method.h
@@ -209,6 +209,8 @@ typedef struct rb_method_sorbet_struct {
 
     const rb_sorbet_param_t *param; /* cf. rb_iseq_constant_body.param */
     rb_iseq_t *iseqptr;
+
+    rb_cref_t * cref;          /*!< class reference, should be marked */
 } rb_method_sorbet_t;
 
 typedef struct rb_method_attr_struct {
@@ -269,10 +271,10 @@ STATIC_ASSERT(sizeof_method_def, offsetof(rb_method_definition_t, body)==8);
      UNDEFINED_METHOD_ENTRY_P((def)->body.refined.orig_me))
 
 void rb_add_method_cfunc(VALUE klass, ID mid, VALUE (*func)(ANYARGS), int argc, rb_method_visibility_t visi);
-void rb_add_method_sorbet(VALUE klass, ID mid, rb_sorbet_func_t func, const rb_sorbet_param_t *param, rb_method_visibility_t visi, void *iseqptr);
+void rb_add_method_sorbet(VALUE klass, ID mid, rb_sorbet_func_t func, const rb_sorbet_param_t *param, rb_method_visibility_t visi, void *iseqptr, rb_cref_t *cref);
 /* included so we don't expose singleton_class_of outside of class.c */
 /* we can't use rb_sorbet_func_t here because it's not exported */
-void rb_define_singleton_sorbet_method(VALUE, const char*, rb_sorbet_func_t, const void *, void *);
+void rb_define_singleton_sorbet_method(VALUE, const char*, rb_sorbet_func_t, const void *, void *, rb_cref_t *cref);
 void rb_add_method_iseq(VALUE klass, ID mid, const rb_iseq_t *iseq, rb_cref_t *cref, rb_method_visibility_t visi);
 void rb_add_refined_method_entry(VALUE refined_class, ID mid);
 void rb_add_method(VALUE klass, ID mid, rb_method_type_t type, void *option, rb_method_visibility_t visi);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -628,6 +628,8 @@ method_entry_cref(rb_callable_method_entry_t *me)
     switch (me->def->type) {
       case VM_METHOD_TYPE_ISEQ:
 	return me->def->body.iseq.cref;
+      case VM_METHOD_TYPE_SORBET:
+        return me->def->body.sorbet.cref;
       default:
 	return NULL;
     }

--- a/vm_method.c
+++ b/vm_method.c
@@ -171,12 +171,13 @@ rb_add_method_cfunc(VALUE klass, ID mid, VALUE (*func)(ANYARGS), int argc, rb_me
 }
 
 void
-rb_add_method_sorbet(VALUE klass, ID mid, rb_sorbet_func_t func, const rb_sorbet_param_t *param, rb_method_visibility_t visi, void *iseqptr)
+rb_add_method_sorbet(VALUE klass, ID mid, rb_sorbet_func_t func, const rb_sorbet_param_t *param, rb_method_visibility_t visi, void *iseqptr, rb_cref_t *cref)
 {
     rb_method_sorbet_t opt;
     opt.func = func;
     opt.param = param;
     opt.iseqptr = (rb_iseq_t *)iseqptr;
+    opt.cref = cref;
     rb_add_method(klass, mid, VM_METHOD_TYPE_SORBET, &opt, visi);
 }
 
@@ -264,11 +265,12 @@ setup_method_cfunc_struct(rb_method_cfunc_t *cfunc, VALUE (*func)(), int argc)
 }
 
 static void
-setup_method_sorbet_struct(rb_method_sorbet_t *sorbet, rb_sorbet_func_t func, const rb_sorbet_param_t *param, rb_iseq_t *iseqptr)
+setup_method_sorbet_struct(rb_method_sorbet_t *sorbet, rb_sorbet_func_t func, const rb_sorbet_param_t *param, rb_iseq_t *iseqptr, rb_cref_t *cref)
 {
     sorbet->func = func;
     sorbet->param = param;
     sorbet->iseqptr = iseqptr;
+    sorbet->cref = cref;
 }
 
 MJIT_FUNC_EXPORTED void
@@ -307,7 +309,7 @@ rb_method_definition_set(const rb_method_entry_t *me, rb_method_definition_t *de
 	  case VM_METHOD_TYPE_SORBET:
 	    {
 		rb_method_sorbet_t *sorbet = (rb_method_sorbet_t *)opts;
-		setup_method_sorbet_struct(UNALIGNED_MEMBER_PTR(def, body.sorbet), sorbet->func, sorbet->param, sorbet->iseqptr);
+		setup_method_sorbet_struct(UNALIGNED_MEMBER_PTR(def, body.sorbet), sorbet->func, sorbet->param, sorbet->iseqptr, sorbet->cref);
 		return;
 	    }
 	  case VM_METHOD_TYPE_ATTRSET:


### PR DESCRIPTION
We need these so that sorbet methods look more like regular Ruby methods, and so we can use various VM machinery for `defined?`.