### PR TITLE
pass rb_calling_info into sorbet method functions

### DIFF
--- a/method.h
+++ b/method.h
@@ -201,8 +201,8 @@ typedef struct rb_sorbet_param_struct {
 
 /* The `void *` parameters are:
  *
- * - struct rb_call_data *
  * - struct rb_calling_info *
+ * - struct rb_call_data *
  *
  * which we can't use here because they're not exported.
  */

--- a/method.h
+++ b/method.h
@@ -199,7 +199,14 @@ typedef struct rb_sorbet_param_struct {
     const ID *kw_table;
 } rb_sorbet_param_t;
 
-typedef VALUE (*rb_sorbet_func_t)(int, VALUE *, VALUE, struct rb_control_frame_struct *, void *);
+/* The `void *` parameters are:
+ *
+ * - struct rb_call_data *
+ * - struct rb_calling_info *
+ *
+ * which we can't use here because they're not exported.
+ */
+typedef VALUE (*rb_sorbet_func_t)(int, VALUE *, VALUE, struct rb_control_frame_struct *, void *, void *);
 
 typedef struct rb_method_sorbet_struct {
     /* cf. rb_method_cfunc_struct, but we only support one argument style */
@@ -271,7 +278,6 @@ STATIC_ASSERT(sizeof_method_def, offsetof(rb_method_definition_t, body)==8);
 void rb_add_method_cfunc(VALUE klass, ID mid, VALUE (*func)(ANYARGS), int argc, rb_method_visibility_t visi);
 void rb_add_method_sorbet(VALUE klass, ID mid, rb_sorbet_func_t func, const rb_sorbet_param_t *param, rb_method_visibility_t visi, void *iseqptr);
 /* included so we don't expose singleton_class_of outside of class.c */
-/* we can't use rb_sorbet_func_t here because it's not exported */
 void rb_define_singleton_sorbet_method(VALUE, const char*, rb_sorbet_func_t, const void *, void *);
 void rb_add_method_iseq(VALUE klass, ID mid, const rb_iseq_t *iseq, rb_cref_t *cref, rb_method_visibility_t visi);
 void rb_add_refined_method_entry(VALUE refined_class, ID mid);

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -143,7 +143,7 @@ vm_call0_sorbet_with_frame(rb_execution_context_t* ec, struct rb_calling_info *c
                                                     block_handler, (VALUE)me,
                                                     0, reg_cfp->sp, sorbet->iseqptr->body->local_table_size, sorbet->iseqptr->body->stack_max);
 
-        val = (*sorbet->func)(argc, argv, recv, new_cfp, cd, calling);
+        val = (*sorbet->func)(argc, argv, recv, new_cfp, calling, cd);
 
 	CHECK_CFP_CONSISTENCY("vm_call0_sorbet_with_frame");
 	rb_vm_pop_frame(ec);

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -143,8 +143,7 @@ vm_call0_sorbet_with_frame(rb_execution_context_t* ec, struct rb_calling_info *c
                                                     block_handler, (VALUE)me,
                                                     0, reg_cfp->sp, sorbet->iseqptr->body->local_table_size, sorbet->iseqptr->body->stack_max);
 
-        /* TODO: eventually we want to pass cd in here to assist with kwargs parsing */
-        val = (*sorbet->func)(argc, argv, recv, new_cfp, cd);
+        val = (*sorbet->func)(argc, argv, recv, new_cfp, cd, calling);
 
 	CHECK_CFP_CONSISTENCY("vm_call0_sorbet_with_frame");
 	rb_vm_pop_frame(ec);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2621,7 +2621,7 @@ vm_call_sorbet_with_frame_normal(rb_execution_context_t *ec, rb_control_frame_t 
                                                 0, ec->cfp->sp, local_size, sorbet->iseqptr->body->stack_max);
 
     reg_cfp->sp -= argc + 1;
-    val = (*sorbet->func)(argc, reg_cfp->sp + 1, recv, new_cfp, cd, calling);
+    val = (*sorbet->func)(argc, reg_cfp->sp + 1, recv, new_cfp, calling, cd);
 
     CHECK_CFP_CONSISTENCY("vm_call_sorbet");
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2621,8 +2621,7 @@ vm_call_sorbet_with_frame_normal(rb_execution_context_t *ec, rb_control_frame_t 
                                                 0, ec->cfp->sp, local_size, sorbet->iseqptr->body->stack_max);
 
     reg_cfp->sp -= argc + 1;
-    /* TODO: eventually we want to pass cd in here to assist with kwargs parsing */
-    val = (*sorbet->func)(argc, reg_cfp->sp + 1, recv, new_cfp, cd);
+    val = (*sorbet->func)(argc, reg_cfp->sp + 1, recv, new_cfp, cd, calling);
 
     CHECK_CFP_CONSISTENCY("vm_call_sorbet");
 


### PR DESCRIPTION
sorbet/ruby#3 changed things so that we pass the `rb_call_data` structure into sorbet method functions.  This is not quite enough to enable efficient parsing of keyword args, since there are actually three pieces of information that we need:

1. `struct rb_call_info`, which indicates the `ID` of the method being called, any keyword args that are passed, and statically-determined call-specific flags (is there a splat argument, can we search for private methods, etc.).  This structure is stored in...
2. `struct rb_call_data`, which is already being passed by the aforementioned PR.  (I suppose we could pass a pointer to `struct rb_call_info` instead of `struct rb_call_data`, since we don't need anything else out of the latter, but passing `struct rb_call_data` is what the VM itself does, so we might as well follow convention.)
3. `struct rb_calling_info`, which is confusingly named and passed separately.

The need for `struct rb_calling_info` is a place to record dynamic behavior about the call..  The easiest place to see this is with regards to keyword splats and splat args: if you have a call with no keyword or keyword splat arguments, a splat argument, and the particular array passed to the splat contains a hash as its last element (and the hash is marked as being a keyword-argument-passing hash):

https://github.com/ruby/ruby/blob/ac7c2754c004cdb3618738e315d2e2cb5f68a3a8/vm_insnhelper.c#L1959-L1972

the last argument is considered as being a keyword splat argument.  But where would that information be recorded?  It can't be recorded as part of the `struct rb_call_info`, since it's not a static thing.  And the behavior can change from call-to-call because it depends on the particular composition of the array being splatted.  So we have this `struct rb_calling_info` to record the dynamic behavior of the splat arg and any keyword splat thing it might produce.

Since we're eventually going to start using the flags in `rb_call_info` to modify the argument-parsing behavior of Sorbet method functions, we need to pass `rb_calling_info` in as well so we have a complete picture of what the particular call did.