### PR TITLE
add the ability to use interpreter-style keyword arg parsing for compiled functions

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2561,7 +2561,8 @@ static bool
 vm_call_kwarg_simple_p(const rb_method_sorbet_t *sorbet)
 {
     const rb_sorbet_param_t *param = sorbet->param;
-    return param->flags.has_rest == FALSE &&
+    return param->flags.has_opt == FALSE &&
+        param->flags.has_rest == FALSE &&
         param->flags.has_post == FALSE &&
         param->flags.has_kw == TRUE &&
         param->flags.has_kwrest == FALSE &&

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2722,7 +2722,9 @@ vm_call_sorbet_fast_0params_0locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 0, 0);
+    const int params = 0;
+    const int locals = 0;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2730,7 +2732,9 @@ vm_call_sorbet_fast_0params_1locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 0, 1);
+    const int params = 0;
+    const int locals = 1;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2738,7 +2742,9 @@ vm_call_sorbet_fast_0params_2locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 0, 2);
+    const int params = 0;
+    const int locals = 2;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2746,7 +2752,9 @@ vm_call_sorbet_fast_0params_3locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 0, 3);
+    const int params = 0;
+    const int locals = 3;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2754,7 +2762,9 @@ vm_call_sorbet_fast_0params_4locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 0, 4);
+    const int params = 0;
+    const int locals = 4;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2762,7 +2772,9 @@ vm_call_sorbet_fast_0params_5locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 0, 5);
+    const int params = 0;
+    const int locals = 5;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2770,7 +2782,9 @@ vm_call_sorbet_fast_1params_0locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 1, 0);
+    const int params = 1;
+    const int locals = 0;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2778,7 +2792,9 @@ vm_call_sorbet_fast_1params_1locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 1, 1);
+    const int params = 1;
+    const int locals = 1;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2786,7 +2802,9 @@ vm_call_sorbet_fast_1params_2locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 1, 2);
+    const int params = 1;
+    const int locals = 2;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2794,7 +2812,9 @@ vm_call_sorbet_fast_1params_3locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 1, 3);
+    const int params = 1;
+    const int locals = 3;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2802,7 +2822,9 @@ vm_call_sorbet_fast_1params_4locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 1, 4);
+    const int params = 1;
+    const int locals = 4;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2810,7 +2832,9 @@ vm_call_sorbet_fast_1params_5locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 1, 5);
+    const int params = 1;
+    const int locals = 5;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2818,7 +2842,9 @@ vm_call_sorbet_fast_2params_0locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 2, 0);
+    const int params = 2;
+    const int locals = 0;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2826,7 +2852,9 @@ vm_call_sorbet_fast_2params_1locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 2, 1);
+    const int params = 2;
+    const int locals = 1;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2834,7 +2862,9 @@ vm_call_sorbet_fast_2params_2locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 2, 2);
+    const int params = 2;
+    const int locals = 2;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2842,7 +2872,9 @@ vm_call_sorbet_fast_2params_3locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 2, 3);
+    const int params = 2;
+    const int locals = 3;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2850,7 +2882,9 @@ vm_call_sorbet_fast_2params_4locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 2, 4);
+    const int params = 2;
+    const int locals = 4;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2858,7 +2892,9 @@ vm_call_sorbet_fast_2params_5locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 2, 5);
+    const int params = 2;
+    const int locals = 5;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2866,7 +2902,9 @@ vm_call_sorbet_fast_3params_0locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 3, 0);
+    const int params = 3;
+    const int locals = 0;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2874,7 +2912,9 @@ vm_call_sorbet_fast_3params_1locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 3, 1);
+    const int params = 3;
+    const int locals = 1;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2882,7 +2922,9 @@ vm_call_sorbet_fast_3params_2locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 3, 2);
+    const int params = 3;
+    const int locals = 2;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2890,7 +2932,9 @@ vm_call_sorbet_fast_3params_3locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 3, 3);
+    const int params = 3;
+    const int locals = 3;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2898,7 +2942,9 @@ vm_call_sorbet_fast_3params_4locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 3, 4);
+    const int params = 3;
+    const int locals = 4;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static VALUE
@@ -2906,7 +2952,9 @@ vm_call_sorbet_fast_3params_5locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, 3, 5);
+    const int params = 3;
+    const int locals = 5;
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
 }
 
 static const vm_call_handler vm_call_sorbet_handlers[][6] = {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2606,7 +2606,7 @@ vm_call_sorbet_optimizable_p(const struct rb_call_info *ci, const struct rb_call
 
     /* If we're calling a keyword-arg taking function that doesn't have other complex
      * arguments, we can avoid turning the keyword args into a keyword splat. */
-    if (vm_call_kwarg_simple_p(sorbet)) {
+    if (vm_call_kwarg_simple_p(sorbet) && IS_ARGS_KEYWORD(ci)) {
         return SORBET_METHOD_OPT_EFFICIENT_KWARGS;
     }
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2673,7 +2673,9 @@ vm_call_sorbet_with_frame(rb_execution_context_t *ec, rb_control_frame_t *reg_cf
     const int check_kw_splat = 1;
     const rb_callable_method_entry_t *me = cd->cc.me;
     const rb_method_sorbet_t *sorbet = UNALIGNED_MEMBER_PTR(me->def, body.sorbet);
-    return vm_call_sorbet_with_frame_normal(ec, reg_cfp, calling, cd, me, check_kw_splat, empty_kw_splat, calling->argc, sorbet->iseqptr->body->local_table_size);
+    const int argc = calling->argc;
+    const int locals = sorbet->iseqptr->body->local_table_size;
+    return vm_call_sorbet_with_frame_normal(ec, reg_cfp, calling, cd, me, check_kw_splat, empty_kw_splat, argc, locals);
 }
 
 static VALUE

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2620,10 +2620,10 @@ vm_call_sorbet_optimizable_p(const struct rb_call_info *ci, const struct rb_call
  * Compare the ALWAYS_INLINE declaration on vm_call_iseq_setup_normal, which
  * works on the same principles.
  */
-ALWAYS_INLINE(static VALUE vm_call_sorbet_with_frame_normal(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct rb_calling_info *calling, struct rb_call_data *cd, const rb_callable_method_entry_t *me, int check_kw_splat, int empty_kw_splat, int param_size, int local_size));
+ALWAYS_INLINE(static VALUE vm_call_sorbet_with_frame_normal(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct rb_calling_info *calling, struct rb_call_data *cd, const rb_callable_method_entry_t *me, int check_kw_splat, int empty_kw_splat, int argc, int param_size, int local_size));
 
 static VALUE
-vm_call_sorbet_with_frame_normal(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct rb_calling_info *calling, struct rb_call_data *cd, const rb_callable_method_entry_t *me, int check_kw_splat, int empty_kw_splat, int param_size, int local_size)
+vm_call_sorbet_with_frame_normal(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct rb_calling_info *calling, struct rb_call_data *cd, const rb_callable_method_entry_t *me, int check_kw_splat, int empty_kw_splat, int argc, int param_size, int local_size)
 {
     const struct rb_call_info *ci = &cd->ci;
     VALUE val;
@@ -2636,7 +2636,6 @@ vm_call_sorbet_with_frame_normal(rb_execution_context_t *ec, rb_control_frame_t 
      * be accessed by Binding#local_variables and that need to be accessed by blocks/closures.
      */
     VALUE frame_type = VM_FRAME_MAGIC_CFUNC | VM_ENV_FLAG_LOCAL;
-    int argc = param_size;
 
     if (check_kw_splat) {
         if (UNLIKELY(calling->kw_splat)) {
@@ -2674,8 +2673,9 @@ vm_call_sorbet_with_frame(rb_execution_context_t *ec, rb_control_frame_t *reg_cf
     const rb_callable_method_entry_t *me = cd->cc.me;
     const rb_method_sorbet_t *sorbet = UNALIGNED_MEMBER_PTR(me->def, body.sorbet);
     const int argc = calling->argc;
+    const int param_size = calling->argc;
     const int locals = sorbet->iseqptr->body->local_table_size;
-    return vm_call_sorbet_with_frame_normal(ec, reg_cfp, calling, cd, me, check_kw_splat, empty_kw_splat, argc, locals);
+    return vm_call_sorbet_with_frame_normal(ec, reg_cfp, calling, cd, me, check_kw_splat, empty_kw_splat, argc, param_size, locals);
 }
 
 static VALUE
@@ -2724,9 +2724,10 @@ vm_call_sorbet_fast_0params_0locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 0;
     const int params = 0;
     const int locals = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2734,9 +2735,10 @@ vm_call_sorbet_fast_0params_1locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 0;
     const int params = 0;
     const int locals = 1;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2744,9 +2746,10 @@ vm_call_sorbet_fast_0params_2locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 0;
     const int params = 0;
     const int locals = 2;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2754,9 +2757,10 @@ vm_call_sorbet_fast_0params_3locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 0;
     const int params = 0;
     const int locals = 3;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2764,9 +2768,10 @@ vm_call_sorbet_fast_0params_4locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 0;
     const int params = 0;
     const int locals = 4;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2774,9 +2779,10 @@ vm_call_sorbet_fast_0params_5locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 0;
     const int params = 0;
     const int locals = 5;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2784,9 +2790,10 @@ vm_call_sorbet_fast_1params_0locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 1;
     const int params = 1;
     const int locals = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2794,9 +2801,10 @@ vm_call_sorbet_fast_1params_1locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 1;
     const int params = 1;
     const int locals = 1;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2804,9 +2812,10 @@ vm_call_sorbet_fast_1params_2locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 1;
     const int params = 1;
     const int locals = 2;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2814,9 +2823,10 @@ vm_call_sorbet_fast_1params_3locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 1;
     const int params = 1;
     const int locals = 3;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2824,9 +2834,10 @@ vm_call_sorbet_fast_1params_4locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 1;
     const int params = 1;
     const int locals = 4;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2834,9 +2845,10 @@ vm_call_sorbet_fast_1params_5locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 1;
     const int params = 1;
     const int locals = 5;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2844,9 +2856,10 @@ vm_call_sorbet_fast_2params_0locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 2;
     const int params = 2;
     const int locals = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2854,9 +2867,10 @@ vm_call_sorbet_fast_2params_1locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 2;
     const int params = 2;
     const int locals = 1;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2864,9 +2878,10 @@ vm_call_sorbet_fast_2params_2locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 2;
     const int params = 2;
     const int locals = 2;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2874,9 +2889,10 @@ vm_call_sorbet_fast_2params_3locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 2;
     const int params = 2;
     const int locals = 3;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2884,9 +2900,10 @@ vm_call_sorbet_fast_2params_4locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 2;
     const int params = 2;
     const int locals = 4;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2894,9 +2911,10 @@ vm_call_sorbet_fast_2params_5locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 2;
     const int params = 2;
     const int locals = 5;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2904,9 +2922,10 @@ vm_call_sorbet_fast_3params_0locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 3;
     const int params = 3;
     const int locals = 0;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2914,9 +2933,10 @@ vm_call_sorbet_fast_3params_1locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 3;
     const int params = 3;
     const int locals = 1;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2924,9 +2944,10 @@ vm_call_sorbet_fast_3params_2locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 3;
     const int params = 3;
     const int locals = 2;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2934,9 +2955,10 @@ vm_call_sorbet_fast_3params_3locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 3;
     const int params = 3;
     const int locals = 3;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2944,9 +2966,10 @@ vm_call_sorbet_fast_3params_4locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 3;
     const int params = 3;
     const int locals = 4;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static VALUE
@@ -2954,9 +2977,10 @@ vm_call_sorbet_fast_3params_5locals(rb_execution_context_t *ec, rb_control_frame
 {
     const int check_kw_splat = 0;
     const int empty_kw_splat = 0;
+    const int argc = 3;
     const int params = 3;
     const int locals = 5;
-    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, params, locals);
+    return vm_call_sorbet_with_frame_normal(ec, cfp, calling, cd, cd->cc.me, check_kw_splat, empty_kw_splat, argc, params, locals);
 }
 
 static const vm_call_handler vm_call_sorbet_handlers[][6] = {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2654,7 +2654,7 @@ vm_call_sorbet_with_frame_normal(rb_execution_context_t *ec, rb_control_frame_t 
                                                 block_handler, (VALUE)me,
                                                 0, ec->cfp->sp, local_size, sorbet->iseqptr->body->stack_max);
 
-    reg_cfp->sp -= argc + 1;
+    reg_cfp->sp -= param_size + 1;
     val = (*sorbet->func)(argc, reg_cfp->sp + 1, recv, new_cfp, calling, cd);
 
     CHECK_CFP_CONSISTENCY("vm_call_sorbet");


### PR DESCRIPTION
## Background

The Ruby VM's calling convention for methods implemented in C is very simple: positional arguments followed by a potential keyword splat argument.  (There are some finer points about how these arguments actually get passed to C functions that we're going to gloss over here.)  This is how arguments are pushed onto the VM's stack and how they are passed to C methods via a `VALUE *` argv.  Sorbet methods inherit this calling convention largely unchanged, though Sorbet methods do have a fast path for methods with a small number of required arguments.

Calls from interpreted code are designed to be more efficient for keyword arguments.  Method calls such as:

```ruby
  f(x, y, key1: z, key2: w)
```

push four arguments onto the Ruby stack, `x`, `y`, `z`, and `w`.  Data associated with the call in `rb_call_info_kw_arg` indicates the number of keyword arguments (2) and their names (`:key1`, `:key2`).  This convention saves stack space (no pushing of the symbols for the keyword arguments).  This `rb_call_info_kw_arg` (and its related `rb_call_info` structure, for calls that don't have keyword arguments) also contains flags indicating salient features of the call: whether it has a splat arg, whether it has keyword splat args, whether the call can call private methods, and so forth.

It's worth noting that just because the keyword arguments are passed "efficiently" on the caller side doesn't mean that the callee can avoid allocating some kind of keyword splat hash in all cases.  The interpreter implements only two cases for avoiding the keyword splat allocation:

1. passing keyword args when the callee takes only required args and keyword args and the caller passed the correct number of required args
2. passing no keyword args when the calle takes only required args and keyword args

But these, particularly the former, are pretty common.  Handling other cases is complicated by Ruby's semantics.

Note that these conventions for calls from interpreted code and methods implemented in compiled code are quite different.  How do these get reconciled at runtime?

The code for Sorbet methods goes through `vm_call_sorbet`:

https://github.com/sorbet/ruby/blob/835f30277a15b0566fa0a23e33ccef4fde517243/vm_insnhelper.c#L2645-L2659

which in turn goes through `CALLER_SETUP_ARGS`:

https://github.com/sorbet/ruby/blob/835f30277a15b0566fa0a23e33ccef4fde517243/vm_insnhelper.c#L1955-L1981

This latter function takes care of:

1. expanding any splat args to the VM stack, possibly noting the existence of a keyword splat arg along the way (!)
2. if keyword args have been passed according to the interpreter convention above, those args are rolled up into a keyword splat arg.

Note that `CALLER_SETUP_ARGS` might affect the truthfulness of the flags associated with the call in the `rb_call_info{,_kw_arg}` structure.  But we can't modify the `rb_call_info{,_kw_arg}` structure associated with the call; the particular behavior of the call after `CALLER_SETUP_ARGS` is determined by the runtime values of the parameters to the call.  So the VM has an entirely separate structure `rb_calling_info`, solely for indicating whether we might have introduced a keyword splat arg along the way.

Part of the benefit of the existing fastpath for required-arg-only functions is that we skip the checks in `CALLER_SETUP_ARGS` (and some other checks underneath `vm_call_sorbet` since we know we cannot have keyword splats).  The other benefits come from being able to reduce some of the arguments to `vm_push_frame` to constants, enabling inlining to do a more effective job.

## Motivation

As you might imagine, rolling up keyword arguments into keyword splats is inefficient, especially when compared to interpreted code:

1. interpreted -> interpreted calls are fine
2. compiled -> interpreted calls are fine (the compiler will arrange things to follow the interpreter's conventions)
3. compiled -> compiled calls are not fine, because we arranged things for the interpreter, but then we allocate on the callee side
4. interpreted -> compiled calls are not fine, because we will always allocate a keyword splat even when we don't need it

This PR implements a fastpath similar to the interpreter's "exact required args + keyword args" handling for dealing with the latter two cases.  This brings us to rough parity with the interpreter for the common case of keyword args.

Note that this PR will require changes in the compiler, since compiled methods can now receive keyword arguments in two different ways.  That compiler change is sorbet/sorbet#4696.

The commits are mostly reviewable on their own.  The big picture runs as follows:

* Since we're adding another fastpath, we need to restructure `vm_call_sorbet_optimizable_p` to not just return true or false, but to indicate what kind of fastpath we can take.
* Once we have the above, we can then add conditions under which we could make an "efficient" keyword args call into compiled code.  (There are several adjustments to this that are not contiguous in the commit series.)
* We can now add the fastpath that skips `CALLER_SETUP_ARGS`.
* Except debugging indicates we have a problem: the Ruby VM, for the call above, indicates that there are 4 arguments: 2 positional and 2 keyword.  But the compiler code assumes that the `argc` it receives only refers to the positional arguments, so we need to adjust the `argc` that we pass in to the compiled method.  But the VM code has been assuming that "number of things on stack for the call" and "`argc` passed to compiled methods" are the same thing, which, for the case of "efficient" keyword args, is not the case.
* So we need to adjust things such that "number of things on stack for the call" and "`argc`" are actually two different things (which might wind up having the same value in some cases).  Once we've done that, we can adjust the `argc` that gets passed to the compiled method.  (This maybe could have been done by having another layer of functions to call, rather than adding more parameters to `vm_call_sorbet_with_frame` and `vm_call_sorbet_with_frame_normal`.)

Happy to talk about the finer points of this over a call.